### PR TITLE
Refactor istio-app-to-app

### DIFF
--- a/source/ssb-chart/templates/istio-app-to-app-auth.yaml
+++ b/source/ssb-chart/templates/istio-app-to-app-auth.yaml
@@ -1,51 +1,48 @@
 {{- if and (eq "backend" .Values.appType) (and ( or (eq (toString .Values.istioAppToAppAuth.enabled) "true") (eq (toString .Values.istioAppToAppAuth.enabled) "True")) .Values.istioAppToAppAuth.enabled) }}
-# Authorization policy to allow for metrics scraping
----
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: "{{ template "app.name" . }}-app-to-app-allow-metrics-auth-policy"
-  labels:
-{{ include "default.labels" . | indent 4 }}
-spec:
-  selector:
-    matchLabels:
-      app: {{ template "app.name" . }}
-  action: ALLOW
-  rules:
-    # From Prometheus service account
-    - from:
-        - source:
-            principals:
-              - cluster.local/ns/monitoring/sa/ssb-prometheus-server
-      # To application metrics endpoint
-      to:
-        - operation:
-            paths:
-              - "{{ .Values.metrics.path }}"
----
 
-# Authorization policy to allow for another app to access (any) endpoints in this app
-{{- if .Values.istioAppToAppAuth.serviceAccounts }}
+# Define template values as variables here, due to range changing scope
+{{- $applicationName := include "app.name" . }}
+{{- $defaultLabels := include "default.labels" . }}
+
+{{- range .Values.istioAppToAppAuth.from }}
+# Authorization policy to allow for another app to access (any) endpoints in this app.
+# One policy for each service account that is allowed to access this app.
+---
+{{- if and .serviceAccount (or .namespace .appName) }}
+{{- fail "You must specify either 'serviceAccount' or 'namespace' & 'appName', not both." }}
+{{- end }}
+
+{{- if and (or .namespace .appName) (not (and .namespace .appName)) }}
+{{- fail "Only one the values ('namespace' or 'appName') were specified. Both must be specified." }}
+{{- end }}
+
+{{- $constructedServiceAccount := "" }}
+{{- if not .serviceAccount }}
+# Construct the service account string when '.namespace' '.appName' configuration is used
+{{- $constructedServiceAccount = printf "cluster.local/ns/%s/sa/%s-sa" .namespace .appName }}
+{{- end }}
+
+{{- $serviceAccount := (default $constructedServiceAccount .serviceAccount) }}
+
+# Create a "user-friendly" name for the service account, used in policy name
+{{- $serviceAccountName := splitList "/" $serviceAccount | last }}
+
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: "{{ template "app.name" . }}-app-to-app-allow-policy"
+  name: "{{ $applicationName }}-to-{{ $serviceAccountName }}-app-to-app-allow-policy"
   labels:
-{{ include "default.labels" . | indent 4 }}
+{{ $defaultLabels | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "app.name" . }}
+      app: {{ $applicationName }}
   action: ALLOW
   rules:
     - from:
         - source:
             # The list of service accounts to grant access
             principals:
-{{- range .Values.istioAppToAppAuth.serviceAccounts }}
-              - "{{ . }}"
-{{- end }}
----
+              - "{{ $serviceAccount }}"
 {{- end }}
 {{- end }}

--- a/source/ssb-chart/templates/istio-app-to-app-promtehus-sa-auth.yaml
+++ b/source/ssb-chart/templates/istio-app-to-app-promtehus-sa-auth.yaml
@@ -1,0 +1,27 @@
+{{- if and (eq "backend" .Values.appType) (and ( or (eq (toString .Values.istioAppToAppAuth.enabled) "true") (eq (toString .Values.istioAppToAppAuth.enabled) "True")) .Values.istioAppToAppAuth.enabled) }}
+# Authorization policy to allow for metrics scraping
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: "{{ template "app.name" . }}-app-to-app-allow-metrics-auth-policy"
+  labels:
+{{ include "default.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "app.name" . }}
+  action: ALLOW
+  rules:
+    # From Prometheus service account
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/monitoring/sa/ssb-prometheus-server
+      # To application metrics endpoint
+      to:
+        - operation:
+            paths:
+              - "{{ .Values.metrics.path }}"
+
+{{- end }}

--- a/source/ssb-chart/tests/istio-authorization-app-to-app-promtehus-sa_test.yaml
+++ b/source/ssb-chart/tests/istio-authorization-app-to-app-promtehus-sa_test.yaml
@@ -1,0 +1,44 @@
+# Tests the istio-app-to-app authorization policies. This should render 0,1 or 2 policies
+# depending on configuration
+
+suite: test authorzation-policy-app-to-app-allow-metrics
+templates:
+  - istio-app-to-app-promtehus-sa-auth.yaml
+tests:
+# Render nothing if not enabled (enabled=false by default)
+  - it: should render nothing if not enabled
+    values:
+      - ./values/default-values.yaml
+    set:
+      appType: frontend
+    asserts:
+      - hasDocuments:
+          count: 0
+
+# If enabled a policy which allows Prometheus scraping should be created
+  - it: should render name, ALLOW action and metrics path in app-to-app policy
+    values:
+      - ./values/istio-authorization-app-to-app-values.yaml
+    release:
+      name: unittest-app-release
+      namespace: unittesting
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: unittest-app
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+                - source:
+                    principals:
+                      - cluster.local/ns/monitoring/sa/ssb-prometheus-server
+              to:
+                - operation:
+                    paths:
+                      - /metrics

--- a/source/ssb-chart/tests/istio-authorization-app-to-app_test.yaml
+++ b/source/ssb-chart/tests/istio-authorization-app-to-app_test.yaml
@@ -15,14 +15,67 @@ tests:
       - hasDocuments:
           count: 0
 
-# If enabled a policy which allows Prometheus scraping should be created
-  - it: should render name, ALLOW action and metrics path in app-to-app policy
+
+# If enabled and service accounts specified a policy with the service accounts should be created
+  - it: should render name, ALLOW action and service accounts in the app-to-app policy
     values:
       - ./values/istio-authorization-app-to-app-values.yaml
+    set:
+      istioAppToAppAuth.from:
+        - serviceAccount: cluster.local/ns/cumulus/sa/unittest-app-b-sa
+        - serviceAccount: cluster.local/ns/cumulus/sa/unittest-app-c-sa
+    release:
+      name: unittest-app-release
+      namespace: unittesting
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: unittest-app
+      - equal:
+          path: spec.action
+          value: ALLOW
+
+
+  - it: should render name, ALLOW action and service accounts in the app-to-app policy, one instance check
+    values:
+      - ./values/istio-authorization-app-to-app-values.yaml
+    set:
+      istioAppToAppAuth.from:
+        - serviceAccount: cluster.local/ns/cumulus/sa/unittest-app-b-sa
+        - serviceAccount: cluster.local/ns/cumulus/sa/unittest-app-c-sa
     release:
       name: unittest-app-release
       namespace: unittesting
     documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: unittest-app
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+              - source:
+                  principals:
+                    - cluster.local/ns/cumulus/sa/unittest-app-b-sa
+
+
+# If enabled and service accounts specified a policy with the service accounts should be created
+  - it: should render name, ALLOW action and namespace appName in the app-to-app policy
+    values:
+      - ./values/istio-authorization-app-to-app-values.yaml
+    set:
+      istioAppToAppAuth.from:
+        - namespace: cumulus
+          appName: unittest-app-c
+    release:
+      name: unittest-app-release
+      namespace: unittesting
     asserts:
       - hasDocuments:
           count: 1
@@ -38,38 +91,26 @@ tests:
             - from:
                 - source:
                     principals:
-                      - cluster.local/ns/monitoring/sa/ssb-prometheus-server
-              to:
-                - operation:
-                    paths:
-                      - /metrics
+                      - cluster.local/ns/cumulus/sa/unittest-app-c-sa
 
-# If enabled and service accounts specified a policy with the service accounts should be created
-  - it: should render name, ALLOW action and service accounts in the app-to-app policy
+  - it: should render name, ALLOW action and service accounts and namespace&appname in the app-to-app policy
     values:
       - ./values/istio-authorization-app-to-app-values.yaml
     set:
-      istioAppToAppAuth.serviceAccounts:
-        - cluster.local/ns/cumulus/sa/unittest-app-b-sa
-        - cluster.local/ns/cumulus/sa/unittest-app-c-sa
+      istioAppToAppAuth.from:
+        - serviceAccount: cluster.local/ns/cumulus/sa/unittest-app-b-sa
+        - serviceAccount: cluster.local/ns/cumulus/sa/unittest-app-c-sa
+        - namespace: cumulus
+          appName: unittest-app-c
     release:
       name: unittest-app-release
       namespace: unittesting
-    documentIndex: 1
     asserts:
       - hasDocuments:
-          count: 2
+          count: 3
       - equal:
           path: spec.selector.matchLabels.app
           value: unittest-app
       - equal:
           path: spec.action
           value: ALLOW
-      - equal:
-          path: spec.rules
-          value:
-            - from:
-                - source:
-                    principals:
-                      - cluster.local/ns/cumulus/sa/unittest-app-b-sa
-                      - cluster.local/ns/cumulus/sa/unittest-app-c-sa

--- a/source/ssb-chart/values.yaml
+++ b/source/ssb-chart/values.yaml
@@ -354,9 +354,14 @@ istioEndUserAuth:
   enabled: true
 
 # -- (object) Application authentication with Istio policies.
-# A list with serviceaccounts (principles) which is to be
-# granted access to endpoints on this application must be
-# provided. Prometheus is granted access by default
+# A list of serviceaccounts (principles) or namespace & appnames
+# which is to be granted access to endpoints on this application must be
+# provided via `from` field. Prometheus is granted access by default.
+# Eg:
+# from:
+# - namespace: cumulus
+#   appname: my-app-name
+# - serviceaccount: my-app-service-account-sa
 # Optional.
 # @notationType -- yaml
 istioAppToAppAuth:


### PR DESCRIPTION
Split prometheus rule to own file, such that it can be tested and treated independently of other rules. Rename "serviceAccounts" -> "from", and allow either serviceAccount or namespace and appname as parameter to define the policies. Create one document for each rule. This allows for extending further if we want to add fine grained access as well.

Example usage:
```
istioAppToAppAuth:
  enabled: true
  from:
    - serviceAccount: cluster.local/ns/cumulus/sa/altinn-instantiator-sa
    - serviceAccount: cluster.local/ns/cumulus/sa/altinn-innkvittering-sa
    - namespace: cumulus
      appname: altinn3-event-generator
```