### PR TITLE
V4 access egress external

### DIFF
--- a/source/ssb-chart/templates/access-egress-external-netpol.yaml
+++ b/source/ssb-chart/templates/access-egress-external-netpol.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.access (and .Values.access.egress .Values.access.egress.external) }}
+# Will only render if addresses and/or ports are defined (need FqdnNetworkPolicy to support hosts field)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: "{{ template "app.name" $ }}-egress-external-netpol"
+  labels:
+{{ include "default.labels" $ | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "app.name" $ }}
+  policyTypes:
+  - Egress
+  egress:
+  # If egress.external is empty this policy will efficiently be like deny all
+  {{- range .Values.access.egress.external }}
+  {{ if or .addresses .ports}}
+{{/*TODO: Fix support for one of ( '-' in the wild is not supported)*/}}
+      {{ if .addresses }}
+       - to:
+        {{- range .addresses }}
+         - ipBlock:
+             cidr: {{ . }}
+        {{- end}}
+      {{- end}}
+{{/*       TODO: Fix ports (same as todo above) */}}
+{{/*      {{ if .ports}}*/}}
+{{/*      ports:*/}}
+{{/*        {{- range .ports }}*/}}
+{{/*        - protocol: {{ .protocol | replace "HTTPS" "TCP"}}*/}}
+{{/*          port: {{ .port }}*/}}
+{{/*        {{- end}}*/}}
+{{/*      {{- end}}*/}}
+    {{- end}}
+  {{- end}}
+
+---
+{{- end}}

--- a/source/ssb-chart/templates/access-egress-external-netpol.yaml
+++ b/source/ssb-chart/templates/access-egress-external-netpol.yaml
@@ -11,29 +11,41 @@ spec:
     matchLabels:
       app: {{ template "app.name" $ }}
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  # If egress.external is empty this policy will efficiently be like deny all
+    # If egress.external is empty this policy will efficiently be like deny all
+    # Construct objects in this array as JSON, since YAML-templating was limited with optional records
+    [
   {{- range .Values.access.egress.external }}
-  {{ if or .addresses .ports}}
-{{/*TODO: Fix support for one of ( '-' in the wild is not supported)*/}}
+    {{ if or .addresses .ports}}
+    {
       {{ if .addresses }}
-       - to:
+      to: [
         {{- range .addresses }}
-         - ipBlock:
-             cidr: {{ . }}
+        {
+          ipBlock: {
+            cidr: {{ . }}
+          },
+        },
         {{- end}}
+      ],
       {{- end}}
-{{/*       TODO: Fix ports (same as todo above) */}}
-{{/*      {{ if .ports}}*/}}
-{{/*      ports:*/}}
-{{/*        {{- range .ports }}*/}}
-{{/*        - protocol: {{ .protocol | replace "HTTPS" "TCP"}}*/}}
-{{/*          port: {{ .port }}*/}}
-{{/*        {{- end}}*/}}
-{{/*      {{- end}}*/}}
+
+      {{ if .ports}}
+      ports: [
+        {{- range .ports }}
+        {
+          protocol: {{ .protocol | replace "HTTPS" "TCP"}},
+          port: {{ .port }},
+        },
+        {{- end}}
+      ]
+      {{- end}}
+      
+    },
     {{- end}}
   {{- end}}
+  ]
 
 ---
 {{- end}}

--- a/source/ssb-chart/templates/access-egress-external-netpol.yaml
+++ b/source/ssb-chart/templates/access-egress-external-netpol.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.access (and .Values.access.egress .Values.access.egress.external) }}
+{{- if (((.Values.access).egress).external) }}
 # Will only render if addresses and/or ports are defined (need FqdnNetworkPolicy to support hosts field)
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -17,6 +17,18 @@ spec:
     # Construct objects in this array as JSON, since YAML-templating was limited with optional records
     [
   {{- range .Values.access.egress.external }}
+    {{ if .hosts }}
+    # PS: If egress.external has rules with hosts all ips (0.0.0.0/0) must be allowed since we don't have FQDNNetworkPolicies
+    {
+      to: [
+        {
+          ipBlock: {
+            cidr: '0.0.0.0/0'
+          }
+        },
+      ]
+    },
+    {{ end }}
     {{ if or .addresses .ports}}
     {
       {{ if .addresses }}

--- a/source/ssb-chart/templates/access-egress-external-serviceentry.yaml
+++ b/source/ssb-chart/templates/access-egress-external-serviceentry.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.access (and .Values.access.egress .Values.access.egress.external) }}
+{{- range $index, $value := .Values.access.egress.external }}
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1beta1
+metadata:
+  name: "{{ template "app.name" $ }}-egress-{{ $index }}-external-se"
+  labels:
+{{ include "default.labels" $ | indent 4 }}
+spec:
+{{/*  TODO: Can both hosts and addresses be specified at the same time? */}}
+  {{- if $value.hosts }}
+  hosts:
+    {{- range $value.hosts }}
+    - {{ . }}
+    {{- end }}
+  # Only add resolution if hosts is specified
+  resolution: DNS
+  {{- end }}
+  {{- if $value.addresses }}
+  addresses:
+    {{- range $value.addresses }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if $value.ports }}
+  ports:
+    {{- range $value.ports }}
+    - name: {{ .name }}
+      number: {{ .port }}
+      protocol: {{ .protocol }}
+    {{- end }}
+  {{- end }}
+  # Export to current namespace to avoid leakage to other namespaces
+  exportTo:
+    - "."
+  location: MESH_EXTERNAL
+---
+{{- end}}
+{{- end}}

--- a/source/ssb-chart/templates/access-egress-external-serviceentry.yaml
+++ b/source/ssb-chart/templates/access-egress-external-serviceentry.yaml
@@ -1,5 +1,10 @@
-{{- if and .Values.access (and .Values.access.egress .Values.access.egress.external) }}
+{{- if (((.Values.access).egress).external) }}
+{{/* use range with index such that we can create uniqe name for object*/}}
 {{- range $index, $value := .Values.access.egress.external }}
+---
+{{- if and $value.hosts $value.addresses }}
+{{- fail "Only one of 'hosts' or 'adresses' can be specified in the same rule"}}
+{{- end }}
 kind: ServiceEntry
 apiVersion: networking.istio.io/v1beta1
 metadata:
@@ -17,6 +22,9 @@ spec:
   resolution: DNS
   {{- end }}
   {{- if $value.addresses }}
+  # Hosts are required field. Set to dummy value
+  hosts:
+    - "dummy-host-{{ $index }}.ssb.no"
   addresses:
     {{- range $value.addresses }}
     - {{ . }}
@@ -34,6 +42,5 @@ spec:
   exportTo:
     - "."
   location: MESH_EXTERNAL
----
 {{- end}}
 {{- end}}

--- a/source/ssb-chart/templates/access-egress-external-serviceentry.yaml
+++ b/source/ssb-chart/templates/access-egress-external-serviceentry.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
 {{ include "default.labels" $ | indent 4 }}
 spec:
-{{/*  TODO: Can both hosts and addresses be specified at the same time? */}}
+{{/*  TODO: Suggestion: throw service entry and implement FQDN Netpol*/}}
   {{- if $value.hosts }}
   hosts:
     {{- range $value.hosts }}

--- a/source/ssb-chart/tests/access-egress-external-netpol_test.yaml
+++ b/source/ssb-chart/tests/access-egress-external-netpol_test.yaml
@@ -33,7 +33,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render a network policy with no egress since no addresses or ports defined
+  - it: should render a network policy with allow egress all ips when hosts is defined
     values:
       - ./values/default-values.yaml
     set:
@@ -42,6 +42,8 @@ tests:
           external:
             - hosts:
                 - "ssb.no"
+              addresses:
+                - "104.154.0.0/15"
     asserts:
       - hasDocuments:
           count: 1
@@ -50,7 +52,13 @@ tests:
           value: unittest-app-egress-external-netpol
       - equal:
           path: spec.egress
-          value: []
+          value:
+            - to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+            - to:
+                - ipBlock:
+                    cidr: 104.154.0.0/15
 
   - it: should render a network policy with egress for ipBlocks defined
     values:

--- a/source/ssb-chart/tests/access-egress-external-netpol_test.yaml
+++ b/source/ssb-chart/tests/access-egress-external-netpol_test.yaml
@@ -1,0 +1,169 @@
+suite: test access ingress external authorization policy
+templates:
+  - access-egress-external-netpol.yaml
+tests:
+
+  - it: should not panic if access is empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not panic if egress is empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render nothing if empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external: [ ]
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a network policy with no egress since no addresses or ports defined
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - hosts:
+                - "ssb.no"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-external-netpol
+      - equal:
+          path: spec.egress
+          value: null
+
+  - it: should render a network policy with egress for ipBlocks defined
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - addresses:
+                - "104.154.0.0/15"
+                - "35.228.140.242/32"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-external-netpol
+      - equal:
+          path: spec.egress
+          value:
+            - to:
+                - ipBlock:
+                    cidr: "104.154.0.0/15"
+                - ipBlock:
+                    cidr: "35.228.140.242/32"
+
+  - it: should render a network policy with egress for ports defined, and should rewrite https protocol to tcp
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - ports:
+                - name: https
+                  number: 443
+                  protocol: HTTPS
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-external-netpol
+      - equal:
+          path: spec.egress
+          value:
+            - ports:
+                - protocol: "TCP"
+                  port: "443"
+
+  - it: should render a network policy with egress and ports defined
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - addresses:
+                - "104.154.0.0/15"
+                - "35.228.140.242/32"
+              ports:
+                - name: https
+                  port: 443
+                  protocol: TCP
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-external-netpol
+      - equal:
+          path: spec.egress
+          value:
+            - to:
+                - ipBlock:
+                    cidr: "104.154.0.0/15"
+                - ipBlock:
+                    cidr: "35.228.140.242/32"
+              ports:
+                - protocol: TCP
+                  port: 443
+
+  - it: should render a network policy with multiple egress and ports defined
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - addresses:
+                - "104.154.0.0/15"
+              ports:
+                - name: https
+                  port: 443
+                  protocol: TCP
+            - addresses:
+                - "35.228.140.242/32"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-external-netpol
+      - equal:
+          path: spec.egress
+          value:
+            - to:
+                - ipBlock:
+                    cidr: "104.154.0.0/15"
+              ports:
+                - protocol: TCP
+                  port: 443
+            - to:
+                - ipBlock:
+                    cidr: "35.228.140.242/32"
+

--- a/source/ssb-chart/tests/access-egress-external-netpol_test.yaml
+++ b/source/ssb-chart/tests/access-egress-external-netpol_test.yaml
@@ -50,7 +50,7 @@ tests:
           value: unittest-app-egress-external-netpol
       - equal:
           path: spec.egress
-          value: null
+          value: []
 
   - it: should render a network policy with egress for ipBlocks defined
     values:
@@ -86,7 +86,7 @@ tests:
           external:
             - ports:
                 - name: https
-                  number: 443
+                  port: 443
                   protocol: HTTPS
     asserts:
       - hasDocuments:
@@ -99,7 +99,7 @@ tests:
           value:
             - ports:
                 - protocol: "TCP"
-                  port: "443"
+                  port: 443
 
   - it: should render a network policy with egress and ports defined
     values:

--- a/source/ssb-chart/tests/access-egress-external-serviceentry_test.yaml
+++ b/source/ssb-chart/tests/access-egress-external-serviceentry_test.yaml
@@ -33,7 +33,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render one service entry for each element
+  - it: should render a service entry for each element
     values:
       - ./values/default-values.yaml
     set:
@@ -58,8 +58,6 @@ tests:
           external:
             - hosts:
                 - "pypi.org"
-              addresses:
-                - "104.154.0.0/15"
               ports:
                 - name: https
                   port: 443
@@ -76,6 +74,38 @@ tests:
             hosts:
               - "pypi.org"
             resolution: DNS
+            ports:
+              - name: https
+                number: 443
+                protocol: HTTPS
+            exportTo:
+              - "."
+            location: MESH_EXTERNAL
+
+  - it: should render ServiceEntry with addresses and port specification
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - addresses:
+                - "104.154.0.0/15"
+              ports:
+                - name: https
+                  port: 443
+                  protocol: HTTPS
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-0-external-se
+      - equal:
+          path: spec
+          value:
+            hosts:
+              - "dummy-host-0.ssb.no"
             addresses:
               - "104.154.0.0/15"
             ports:
@@ -86,3 +116,17 @@ tests:
               - "."
             location: MESH_EXTERNAL
 
+  - it: should fail if both hosts and adresses are specified
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - hosts:
+                - "pypi.org"
+              addresses:
+                - "104.154.0.0/15"
+    asserts:
+      - failedTemplate:
+          errorMessage: Only one of 'hosts' or 'adresses' can be specified in the same rule

--- a/source/ssb-chart/tests/access-egress-external-serviceentry_test.yaml
+++ b/source/ssb-chart/tests/access-egress-external-serviceentry_test.yaml
@@ -1,0 +1,88 @@
+suite: test access ingress external authorization policy
+templates:
+  - access-egress-external-serviceentry.yaml
+tests:
+
+  - it: should not panic if access is empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not panic if egress is empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render nothing if empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external: [ ]
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render one service entry for each element
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - hosts:
+                - "nrk.no"
+                - "ssb.no"
+            - addresses:
+                - "104.154.0.0/15"
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render ServiceEntry with host and resolution DNS
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        egress:
+          external:
+            - hosts:
+                - "pypi.org"
+              addresses:
+                - "104.154.0.0/15"
+              ports:
+                - name: https
+                  port: 443
+                  protocol: HTTPS
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-egress-0-external-se
+      - equal:
+          path: spec
+          value:
+            hosts:
+              - "pypi.org"
+            resolution: DNS
+            addresses:
+              - "104.154.0.0/15"
+            ports:
+              - name: https
+                number: 443
+                protocol: HTTPS
+            exportTo:
+              - "."
+            location: MESH_EXTERNAL
+

--- a/source/ssb-chart/values.yaml
+++ b/source/ssb-chart/values.yaml
@@ -278,7 +278,7 @@ access:
       - application: app3
         namespace: n2
 
-      # Allow traffic and do JWT validering from app3 from namespace n3
+      # Allow traffic and do JWT validation from app3 from namespace n3
       - application: app3
         namespace: n3
         rules:
@@ -301,25 +301,13 @@ access:
           - methods: ["GET"]
             paths: ["api/"]
   egress:
-  # Note: Cloudsql should still be configured via cloudsql-flag
     external:
-      # Ekstern egress kan implementeres med en kombinasjon av
-      # NetworkPolicy og (Istio ServiceEntry eller FQDN NetworkPolicy)
-      # Allow HTTPS traffic to host
+      # Note: Cloudsql should still be configured via cloudsql-flag
       - addresses:
           - "104.154.0.0/15"
         ports:
           - name: rabbit-mq
             port: 5671
-            #TODO: Consider if only netpol protocols should be allowed (i.e. not HTTPS and other that ServiceEntry supports)
-            protocol: TCP
-      # Allow TCP traffic to host or IP address on port/protocol
-      - addresses:
-          - x.x.x.x
-        ports:
-          - name: rabbit-mq
-            port: 5671
-            #TODO: Consider if only netpol protocols should be allowed (i.e. not HTTPS and other that ServiceEntry supports)
             protocol: TCP
       - hosts:
           - "firestore.googleapis.com"
@@ -328,11 +316,9 @@ access:
         ports:
           - name: https
             number: 443
-            #TODO: Consider if only netpol protocols should be allowed (i.e. not HTTPS and other that ServiceEntry supports)
+            # HTTPS are supported, and will be replaced with TCP in netpol (implementation detail)
             protocol: HTTPS
     internal:
-      # Intern egress kan kun implementeres med NetworkPolicy på L4
-      # Allow egress to app3 in namespace n3
       - application: app3
         namespace: n3
 

--- a/source/ssb-chart/values.yaml
+++ b/source/ssb-chart/values.yaml
@@ -301,18 +301,37 @@ access:
           - methods: ["GET"]
             paths: ["api/"]
   egress:
-#    external:
-#      # Ekstern egress kan implementeres med en kombinasjon av
-#      # NetworkPolicy og (Istio ServiceEntry eller FQDN NetworkPolicy)
-#      # Allow HTTPS traffic to host
-#      - host: pypi.org
-#      # Allow TCP traffic to host or IP address on port/protocol
-#      - host: x.x.x.x
-#        ports:
-#          - name: cloudsql
-#            port: 3307
-#            protocol: TCP
-#
+  # Note: Cloudsql should still be configured via cloudsql-flag
+    external:
+      # Ekstern egress kan implementeres med en kombinasjon av
+      # NetworkPolicy og (Istio ServiceEntry eller FQDN NetworkPolicy)
+      # Allow HTTPS traffic to host
+      - hosts:
+          - "pypi.org"
+        addresses:
+          - "104.154.0.0/15"
+        ports:
+          - name: rabbit-mq
+            port: 5671
+            #TODO: Consider if only netpol protocols should be allowed (i.e. not HTTPS and other that ServiceEntry supports)
+            protocol: TCP
+      # Allow TCP traffic to host or IP address on port/protocol
+      - addresses:
+          - x.x.x.x
+        ports:
+          - name: rabbit-mq
+            port: 5671
+            #TODO: Consider if only netpol protocols should be allowed (i.e. not HTTPS and other that ServiceEntry supports)
+            protocol: TCP
+      - hosts:
+          - "firestore.googleapis.com"
+          - "ssb-team-forbruk-firebase-default-rtdb.europe-west1.firebasedatabase.app"
+          - "ssb-team-forbruk-firebase.firebaseapp.com"
+        ports:
+          - name: https
+            number: 443
+            #TODO: Consider if only netpol protocols should be allowed (i.e. not HTTPS and other that ServiceEntry supports)
+            protocol: HTTPS
     internal:
       # Intern egress kan kun implementeres med NetworkPolicy på L4
       # Allow egress to app3 in namespace n3

--- a/source/ssb-chart/values.yaml
+++ b/source/ssb-chart/values.yaml
@@ -306,9 +306,7 @@ access:
       # Ekstern egress kan implementeres med en kombinasjon av
       # NetworkPolicy og (Istio ServiceEntry eller FQDN NetworkPolicy)
       # Allow HTTPS traffic to host
-      - hosts:
-          - "pypi.org"
-        addresses:
+      - addresses:
           - "104.154.0.0/15"
         ports:
           - name: rabbit-mq


### PR DESCRIPTION
Add support for specifying access rule for egress towards external hosts and adresses.
Use NetworkPolicy and ServiceEntry as implementation;

Notes to be aware of: 
- `hosts` and `addresses` can not be specified in the same element.
- A networkPolicy with allow egress to `0.0.0.0/0` (all IPs) will be defined if `hosts` are defined, since netpol doesn't support dns resolution.
- Service entries that are created will be per namespace, as there is a limitation in Istio (limiting on workload is not possible).

E.g.:
```yaml
access:
  egress:
    external:
      # Note: Cloudsql should still be configured via cloudsql-flag
      - addresses:
          - "104.154.0.0/15"
        ports:
          - name: rabbit-mq
            port: 5671
            protocol: TCP
      - hosts:
          - "firestore.googleapis.com"
          - "ssb-team-forbruk-firebase-default-rtdb.europe-west1.firebasedatabase.app"
          - "ssb-team-forbruk-firebase.firebaseapp.com"
        ports:
          - name: https
            number: 443
            # HTTPS are supported, and will be replaced with TCP in netpol (implementation detail)
            protocol: HTTPS
```