### PR TITLE
V4 access ingress external

### DIFF
--- a/source/ssb-chart/templates/access-ingress-default-netpol-deny-all.yaml
+++ b/source/ssb-chart/templates/access-ingress-default-netpol-deny-all.yaml
@@ -1,0 +1,14 @@
+# Default deny all ingress network traffic
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: "{{ template "app.name" $ }}-ingress-deny-all"
+  labels:
+{{ include "default.labels" $ | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "app.name" . }}
+  policyTypes:
+    - Ingress
+  ingress: [ ]

--- a/source/ssb-chart/templates/access-ingress-external-authorization-policy.yaml
+++ b/source/ssb-chart/templates/access-ingress-external-authorization-policy.yaml
@@ -1,0 +1,93 @@
+{{- if ((((.Values.access).ingress).external).gateways) }}
+{{- $avaliableTypePrincipals := dict "public" "cluster.local/ns/istio-system/sa/istio-ingressgateway" }}
+{{- range .Values.access.ingress.external.gateways }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: "{{ template "app.name" $ }}-ingress-{{.type }}-gateway"
+  labels:
+{{ include "default.labels" $ | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "app.name" $ }}
+  action: ALLOW
+  rules:
+    {{- $principalInUse := index $avaliableTypePrincipals .type }}
+  {{- if not .rules }}
+    - from:
+        - source:
+            principals: [ "{{ required "unsupported gateway type specified" $principalInUse }}" ]
+  {{- else }}
+    {{- range .rules }}
+    - from:
+        - source:
+            principals: [ "{{ $principalInUse }}" ]
+            {{- if .jwt }}
+            {{- /* The request identity is in the format of "<ISS>/<SUB>" */}}
+            requestPrincipals: [ "{{ required "issuer is required when jwt is in use" .jwt.issuer }}/*" ]
+            {{- end}}
+      {{- if or .paths .methods }}
+      to:
+        - operation:
+
+            {{- if .paths}}
+            paths:
+              {{- range .paths }}
+              - "{{ . }}"
+              {{- end }}
+            {{- end }}
+            {{- if .methods}}
+            methods:
+              {{- range .methods }}
+              - "{{ . }}"
+              {{- end }}
+            {{- end }}
+      {{- end }}
+      {{- if .when }}
+      when:
+        {{ toYaml .when | nindent 6 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+---
+{{- if .rules }}
+    {{/* Merge all jwt-rules into one list, such that we only need one RequestAuthentication per element in access.ingress.internal */}}
+    {{- $jwtRules := list }}
+    {{- range .rules }}
+      {{- if .jwt }}
+        {{- $jwtRules = append $jwtRules .jwt }}
+      {{- end }}
+    {{- end }}
+    {{- if $jwtRules }}
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
+metadata:
+  name: "{{ template "app.name" $ }}-ingress-{{.type }}-request-auth"
+  labels:
+{{ include "default.labels" $| indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "app.name" $ }}
+  jwtRules:
+    # Istio will use OpenId discovery to fetch
+    # the public certificate needed to validate JWT signatures.
+      {{- range $jwtRules }}
+    - issuer: "{{ .issuer }}"
+      # Only allow the request if the JWT contains at least one audience match
+      # in the list below.
+      audiences:
+        - "{{ required "Audience is required if jwt is in use" .audience }}"
+      # Forward this token to the upstream application so it can read user info
+      # from the JWT or use it for authentication in calls to other backends.
+      forwardOriginalToken: true
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end}}
+{{- end}}
+
+
+

--- a/source/ssb-chart/templates/access-ingress-external-istio-gateway-netpol.yaml
+++ b/source/ssb-chart/templates/access-ingress-external-istio-gateway-netpol.yaml
@@ -1,0 +1,22 @@
+{{- if ((((.Values.access).ingress).external).gateways) }}
+{{/*  TODO: CHeck if this netpol already exist in platform or k8s-config-overlays */}}
+# Allow ingress from istio ingress gateway
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: "{{ template "app.name" $ }}-ingress-istio-gateway-netpol"
+  labels:
+{{ include "default.labels" $ | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "app.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              istio: ingressgateway
+          namespaceSelector: {}
+  {{- end }}

--- a/source/ssb-chart/templates/access-ingress-internal-netpol.yaml
+++ b/source/ssb-chart/templates/access-ingress-internal-netpol.yaml
@@ -1,0 +1,24 @@
+{{- if (((.Values.access).ingress).internal) }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: "{{ template "app.name" $ }}-ingress-internal-netpol"
+  labels:
+{{ include "default.labels" $ | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "app.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- range .Values.access.ingress.internal }}
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ .application }}
+          namespaceSelector:
+            matchLabels:
+              name: {{ .namespace }}
+  {{- end }}
+  {{- end }}

--- a/source/ssb-chart/tests/access-ingress-default-netpol-deny-all_test.yaml
+++ b/source/ssb-chart/tests/access-ingress-default-netpol-deny-all_test.yaml
@@ -1,0 +1,30 @@
+suite: test access ingress internal authorization policy
+templates:
+  - access-ingress-default-netpol-deny-all.yaml
+tests:
+
+  - it: should always render
+    values:
+      - ./values/default-values.yaml
+    set:
+      access: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render ingress policy with deny all
+    values:
+      - ./values/default-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-deny-all
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Ingress
+      - equal:
+          path: spec.ingress
+          value: []

--- a/source/ssb-chart/tests/access-ingress-external-authorization-policy-jwt_test.yaml
+++ b/source/ssb-chart/tests/access-ingress-external-authorization-policy-jwt_test.yaml
@@ -1,0 +1,112 @@
+suite: test access ingress internal where jwt rules are specified
+templates:
+  - access-ingress-external-authorization-policy.yaml
+tests:
+
+  - it: should render two documents
+    values:
+      - ./values/access-ingress-external-authorization-policy-jwt-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: authorization policy  should include default labels and name
+    values:
+       - ./values/access-ingress-external-authorization-policy-jwt-values.yaml
+    release:
+      name: unittest-app-release
+      namespace: unittesting
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: unittest-app
+      - equal:
+          path: metadata.labels.billing-project
+          value: ssb-unittest
+      - matchRegex:
+          path: metadata.labels.chart
+          pattern: ^ssb-chart-
+      - equal:
+          path: metadata.labels.release
+          value: unittest-app-release
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-public-gateway
+      - isKind:
+          of: AuthorizationPolicy
+
+  - it: request authentication should include default labels and name in request authentication
+    values:
+       - ./values/access-ingress-external-authorization-policy-jwt-values.yaml
+    release:
+      name: unittest-app-release
+      namespace: unittesting
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: unittest-app
+      - equal:
+          path: metadata.labels.billing-project
+          value: ssb-unittest
+      - matchRegex:
+          path: metadata.labels.chart
+          pattern: ^ssb-chart-
+      - equal:
+          path: metadata.labels.release
+          value: unittest-app-release
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-public-request-auth
+      - isKind:
+          of: RequestAuthentication
+
+  - it: authorization policy should render name, ALLOW action to paths in rules
+    values:
+       - ./values/access-ingress-external-authorization-policy-jwt-values.yaml
+    release:
+      name: unittest-app-release
+      namespace: unittesting
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: unittest-app
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+                - source:
+                    principals:
+                      - "cluster.local/ns/istio-system/sa/istio-ingressgateway"
+                    requestPrincipals:
+                      - "https://sso.example.com/auth/realms/ssb/*"
+              to:
+              - operation:
+                  paths:
+                    - "api/"
+                  methods:
+                    - "GET"
+
+  - it: request authentication should render name, ALLOW action to paths in rules
+    values:
+       - ./values/access-ingress-external-authorization-policy-jwt-values.yaml
+    release:
+      name: unittest-app-release
+      namespace: unittesting
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: unittest-app
+      - equal:
+          path: spec.jwtRules
+          value:
+            - issuer: "https://sso.example.com/auth/realms/ssb"
+              audiences:
+                - "ekstern-client-id"
+              forwardOriginalToken: true

--- a/source/ssb-chart/tests/access-ingress-external-authorization-policy_test.yaml
+++ b/source/ssb-chart/tests/access-ingress-external-authorization-policy_test.yaml
@@ -1,0 +1,184 @@
+suite: test access ingress internal authorization policy
+templates:
+  - access-ingress-external-authorization-policy.yaml
+tests:
+
+  - it: should not panic if empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render nothing if ingress external is empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render nothing if gateways is empty
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways: [ ]
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail if invalid gateway type
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways:
+              - type: foo
+    asserts:
+      - failedTemplate:
+          errorMessage: "unsupported gateway type specified"
+
+  - it: should render authorization policy
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways:
+              - type: public
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-public-gateway
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+                - source:
+                    principals:
+                      - cluster.local/ns/istio-system/sa/istio-ingressgateway
+
+  - it: should render authorization policy with methods in rule
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways:
+              - type: public
+                rules:
+                  - methods: [ "get", "post" ]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-public-gateway
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+                - source:
+                    principals:
+                      - cluster.local/ns/istio-system/sa/istio-ingressgateway
+              to:
+                - operation:
+                    methods:
+                      - "get"
+                      - "post"
+
+
+  - it: should render authorization policy with methods and when in rule
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways:
+              - type: public
+                rules:
+                  - methods: [ "GET" ]
+                    when:
+                      - key: request.headers[Authorization]
+                        values: [ "Bearer *" ]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-public-gateway
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+                - source:
+                    principals:
+                      - cluster.local/ns/istio-system/sa/istio-ingressgateway
+              to:
+                - operation:
+                    methods:
+                      - "GET"
+              when:
+                - key: request.headers[Authorization]
+                  values: [ "Bearer *" ]
+
+
+  - it: should render authorization policy with methods and paths in rule
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways:
+              - type: public
+                rules:
+                  - methods: [ "get" ]
+                    paths: [ "api/" ]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-public-gateway
+      - equal:
+          path: spec.action
+          value: ALLOW
+      - equal:
+          path: spec.rules
+          value:
+            - from:
+                - source:
+                    principals:
+                      - cluster.local/ns/istio-system/sa/istio-ingressgateway
+              to:
+                - operation:
+                    paths:
+                      - "api/"
+                    methods:
+                      - "get"

--- a/source/ssb-chart/tests/access-ingress-external-istio-gateway-netpol_test.yaml
+++ b/source/ssb-chart/tests/access-ingress-external-istio-gateway-netpol_test.yaml
@@ -1,0 +1,32 @@
+suite: test access ingress internal authorization policy
+templates:
+  - access-ingress-external-istio-gateway-netpol.yaml
+tests:
+
+  - it: should render ingress policy with allow from istio ingress gateway
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          external:
+            gateways:
+              - type: public
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-istio-gateway-netpol
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Ingress
+      - equal:
+          path: spec.ingress
+          value:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      istio: ingressgateway
+                  namespaceSelector: { }

--- a/source/ssb-chart/tests/access-ingress-internal-netpol_test.yaml
+++ b/source/ssb-chart/tests/access-ingress-internal-netpol_test.yaml
@@ -1,0 +1,44 @@
+suite: test access ingress internal authorization policy
+templates:
+  - access-ingress-internal-netpol.yaml
+tests:
+
+  - it: should render ingress policy with allow from specified apps
+    values:
+      - ./values/default-values.yaml
+    set:
+      access:
+        ingress:
+          internal:
+            - application: app2
+              namespace: n1
+            - application: app3
+              namespace: n2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: unittest-app-ingress-internal-netpol
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Ingress
+      - equal:
+          path: spec.ingress
+          value:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app: "app2"
+                  namespaceSelector:
+                    matchLabels:
+                      name: "n1"
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app: "app3"
+                  namespaceSelector:
+                    matchLabels:
+                      name: "n2"
+

--- a/source/ssb-chart/tests/values/access-ingress-external-authorization-policy-jwt-values.yaml
+++ b/source/ssb-chart/tests/values/access-ingress-external-authorization-policy-jwt-values.yaml
@@ -1,0 +1,19 @@
+name: "unittest-app"
+namespace: "unittest"
+appType: "backend"
+cluster: "test-cluster"
+billingProject: "ssb-unittest"
+image:
+  repository: ssb.no/unittest-app
+  tag: '1.0'
+access:
+  ingress:
+    external:
+      gateways:
+        - type: public
+          rules:
+            - methods: [ "GET" ]
+              paths: [ "api/" ]
+              jwt:
+                issuer: https://sso.example.com/auth/realms/ssb
+                audience: ekstern-client-id

--- a/source/ssb-chart/values.yaml
+++ b/source/ssb-chart/values.yaml
@@ -254,18 +254,18 @@ networkpolicy:
   # Policy example for an app with SA/name "app1" in namespace "n1"
 access:
   ingress:
-#    external:
-#      # Technical impl. details: In order to allow ingress from an ingress gateway
-#      # the Istio AuthorizationPolicy need to specify the principal of the gateway. E.g:
-#      #   principal: cluster.local/ns/istio-system/sa/istio-ingressgateway
-#      gateways:
-#        - type: public # Same as current "exposed: true"
-#          rules:
-#            - method: ["get"]
-#              path: ["api/"]
-#              jwt:
-#                issuer: https://sso.example.com/auth/realms/ssb
-#                audience: ekstern-client-id
+    external:
+      # Technical impl. details: In order to allow ingress from an ingress gateway
+      # the Istio AuthorizationPolicy need to specify the principal of the gateway. E.g:
+      #   principal: cluster.local/ns/istio-system/sa/istio-ingressgateway
+      gateways:
+        - type: public # Same as current "exposed: true"
+          rules:
+            - methods: ["get"]
+              paths: ["api/"]
+              jwt:
+                issuer: https://sso.example.com/auth/realms/ssb
+                audience: ekstern-client-id
 #        - type: ssb-internal # Does not exist today, but could be used for SSB internal ingress.
 #          rules:
 #            - methods: ["POST"]


### PR DESCRIPTION
Allow ingress external by specifying gateway type. P.t. only `public` is supported, but one can think that other will be added later (such as `ssb-internal` e.g., which could set some requirements as login in front or other).

Usage:
```yaml
access:
  ingress:
    external:
      gateways:
        - type: public # Same as current "exposed: true"
          rules:
            - methods: ["get"]
              paths: ["api/"]
              jwt:
                issuer: https://sso.example.com/auth/realms/ssb
                audience: ekstern-client-id
```