### PR TITLE
Add tmp volume as default to deployment

### DIFF
--- a/source/ssb-chart/templates/deployment.yaml
+++ b/source/ssb-chart/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
           {{- end }}
           {{- if or (.Values.configs) (.Values.volumeMounts) (and ( or (eq (toString .Values.persistence.enabled) "true") (eq (toString .Values.persistence.enabled) "True")) .Values.persistence.enabled) }}
           volumeMounts:
+          - name: tmp-volume
+            mountPath: /tmp
           {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | trim | indent 10 }}
           {{- end }}
@@ -213,6 +215,8 @@ spec:
 {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | trim | indent 8 }}
 {{- end }}
+        - name: tmp-volume
+          emptyDir: { }
 {{- if and (and ( or (eq (toString .Values.oauth2Proxy.enabled) "true") (eq (toString .Values.oauth2Proxy.enabled) "True")) .Values.oauth2Proxy.enabled) (eq .Values.appType "frontend") }}
         - name: "oauth2-proxy-client-config"
           secret:

--- a/source/ssb-chart/tests/__snapshot__/helmrelease-backend-all-values_test.yaml.snap
+++ b/source/ssb-chart/tests/__snapshot__/helmrelease-backend-all-values_test.yaml.snap
@@ -197,6 +197,8 @@ should render Deployment:
               seccompProfile:
                 type: Unrestricted
             volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
             - mountPath: /path/to/secrets
               name: secret-volume
               readOnly: true
@@ -245,6 +247,8 @@ should render Deployment:
                 path: myconfig.cfg
               name: configmap-name
             name: config-volume
+          - emptyDir: {}
+            name: tmp-volume
           - configMap:
               name: unittest-app-application-config
             name: application-config-volume

--- a/source/ssb-chart/tests/__snapshot__/helmrelease-frontend-all-values_test.yaml.snap
+++ b/source/ssb-chart/tests/__snapshot__/helmrelease-frontend-all-values_test.yaml.snap
@@ -221,6 +221,8 @@ should render Deployment:
               seccompProfile:
                 type: Unrestricted
             volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
             - mountPath: /path/to/secrets
               name: secret-volume
               readOnly: true
@@ -269,6 +271,8 @@ should render Deployment:
                 path: myconfig.cfg
               name: configmap-name
             name: config-volume
+          - emptyDir: {}
+            name: tmp-volume
           - name: oauth2-proxy-client-config
             secret:
               secretName: oauth2-proxy-config-unittest-app


### PR DESCRIPTION
To avoid workaround for read/write to temporary folders, since readOnlyRootFilesystem will be enforced from v3 (pod security context). We'll assume everyone has use for this volume

Internal ref: [SKYINFRA-321]

[SKYINFRA-321]: https://statistics-norway.atlassian.net/browse/SKYINFRA-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ